### PR TITLE
Add `channel_reco` in frontend

### DIFF
--- a/frontend/pages/📺_Recommend_Channel.py
+++ b/frontend/pages/📺_Recommend_Channel.py
@@ -1,0 +1,62 @@
+"""
+Upload your subscribed channels data (exported from Google Takeout) to get
+recommendation of similar channels.
+"""
+
+import polars as pl
+import streamlit as st
+
+import st_utils
+from configs import INGESTED_YT_HISTORY_DATA_PATH, VIDEO_DETAILS_JSON_PATH
+from youtube.channel_reco import (
+    RecommendChannels,
+    add_subscribed_column,
+    check_if_subscribed_column_exists,
+)
+
+st.set_page_config("Recommend Channel", "😃", "wide", "expanded")
+st_msg = st.container()
+st_utils.delete_user_data_button()
+
+if not INGESTED_YT_HISTORY_DATA_PATH.exists():
+    st.switch_page("/pages/🐻‍❄️_YT_History_Basic.py")
+if not VIDEO_DETAILS_JSON_PATH.exists():
+    st_msg.error("First collect data of YouTube Videos.", icon="🤖")
+    st.stop()
+ingested_data = st_utils.get_ingested_yt_history_df()
+video_details_data = pl.read_json(VIDEO_DETAILS_JSON_PATH)
+
+try:
+    check_if_subscribed_column_exists(ingested_data)
+    st.title("Recommend Channels from you Subscribed Channels")
+except ValueError:
+    uploaded_file = st_msg.file_uploader(
+        "Upload your subscribed channels data file. (.csv)", type=".csv"
+    )
+    if uploaded_file is None:
+        st.stop()
+    # Update the ingested_data and write into file
+    add_subscribed_column(ingested_data, pl.read_csv(uploaded_file)).write_json(
+        INGESTED_YT_HISTORY_DATA_PATH
+    )
+    st.rerun()
+
+try:
+    recommendation = RecommendChannels(ingested_data, video_details_data)
+except ValueError as e:
+    st_msg.error(e)
+    st.stop()
+
+sl_channel_title = st.selectbox(
+    "Select Channel",
+    recommendation.data["channelTitle"].unique().sort().to_list(),
+)
+if sl_channel_title is None:
+    st.stop()
+
+st.dataframe(
+    recommendation.get_recommendations(sl_channel_title).sort(
+        "similarity", descending=True
+    ),
+    use_container_width=True,
+)

--- a/frontend/youtube/channel_reco.py
+++ b/frontend/youtube/channel_reco.py
@@ -1,0 +1,49 @@
+import httpx
+import polars as pl
+
+from configs import API_HOST_URL
+
+
+def check_if_subscribed_column_exists(ingested_data: pl.DataFrame) -> None:
+    """Check if "subscribed" column exists in data."""
+    if "subscribed" not in ingested_data.columns:
+        raise ValueError("Ingested data does not contain 'subscribed' column.")
+
+
+def add_subscribed_column(
+    ingested_data: pl.DataFrame,
+    subscribed_channels: pl.DataFrame,
+) -> pl.DataFrame:
+    """Add `"subscribed"` column to ingested data."""
+    return ingested_data.with_columns(
+        pl.col("channelId").is_in(subscribed_channels["Channel Id"]).alias("subscribed")
+    )
+
+
+class RecommendChannels:
+    """Class for making recommendations for a channel."""
+
+    def __init__(
+        self, ingested_data: pl.DataFrame, video_details_data: pl.DataFrame
+    ) -> None:
+        check_if_subscribed_column_exists(ingested_data)
+        self.data = video_details_data.join(
+            ingested_data.filter(pl.col("subscribed").eq(True)),
+            left_on="id",
+            right_on="videoId",
+        ).select("title", "tags", "channelId", "channelTitle")
+
+    def get_recommendations(self, channel_title: str) -> pl.DataFrame:
+        """Get recommendations for a channel."""
+        query_channel = self.data.filter(pl.col("channelTitle").eq(channel_title))
+        res = httpx.post(
+            f"{API_HOST_URL}/ml/channel_reco/predict?channels=true",
+            json=query_channel.to_dicts(),
+        )
+        if res.status_code == 200:
+            return pl.DataFrame._from_dicts(res.json())
+        raise httpx.HTTPStatusError(
+            f"Error while making request: {res.text}",
+            request=res.request,
+            response=res,
+        )


### PR DESCRIPTION
> [!IMPORTANT]
>
> `../data/videoDetails.json` data is required for channel recommendation which is gather using user's watch history and **YouTube Data v3 API** (requires `YT_API_KEY`).

- Add `frontend/pages/📺_Recommend_Channel.py`.
- Collects `subscriptions.csv` file with `Channel Id` as a required column. (Because I am merging the `ingested_data` and `subscriptions.csv`)
- Uses `/ml/channel_reco/predict` API endpoint for channel recommendation.
